### PR TITLE
accept any environment name

### DIFF
--- a/e2e_tests/createEnv.sh
+++ b/e2e_tests/createEnv.sh
@@ -2,11 +2,11 @@
 
 # when testing this locally, you'll have to first set the following environment variables in your bash session:
     # export GH_API_TOKEN=(your personal github token)
-    # export BRANCH_KEY=(the key used by test-instance to set the branch of the project in PR)
-    # export PR_REF=(the PR source branch name)
-    # export PR_NUMBER=(the PR number)
+    # export BRANCH_KEY=(the key used by test-instance to set the branch for this project)
+    # export BRANCH_VALUE=(the name of the branch that should be deployed)
+    # export UNIQUE_ENV_NAME=(the name to use for the on-demand environment)
 
-createEnvResponse=$(curl -L --write-out "%{http_code}" --silent --output /dev/null -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_API_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/CardFlight/test-instance/dispatches -d "{\"event_type\": \"create-on-demand-env\", \"client_payload\": {\"$BRANCH_KEY\": \"$PR_REF\", \"uniqueEnvName\": \"pr$PR_NUMBER\"}}")
+createEnvResponse=$(curl -L --write-out "%{http_code}" --silent --output /dev/null -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_API_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/CardFlight/test-instance/dispatches -d "{\"event_type\": \"create-on-demand-env\", \"client_payload\": {\"$BRANCH_KEY\": \"$BRANCH_VALUE\", \"uniqueEnvName\": \"$UNIQUE_ENV_NAME\"}}")
 
 if [[ $createEnvResponse -ne "204" ]];
 then


### PR DESCRIPTION
The scripts in this repo both assume the environment name has to be "pr(PR_NUMBER)", which is problematic for several reasons:
1. this is making it more awkward to test changes made to ODE environments (i.e. data changes, or a change to the workflow in test-instance) from other workflows.  It's a long explanation, but if the next two reasons aren't sufficient in themselves I'd be glad to explain this point more with an example.
2. creating envs named "pr(PR_NUMBER)" doesn't scale well as we have more repos.  Imagine we have two newer repos.  It's quite possible that we'd have a PR in each with id 5 that both run tests near the same time, and there's a collision because they both trigger a deployment to "pr5".  Even if the collision doesn't happen, it's hard to historically tell what OD envs were for what PRs in this naming convention.
3. there's nothing about the scripts that means they would only work if the job was triggered from a PR, so there's no reason to assume that context within them.  I.e. these scripts should work if we instead were triggering them from a workflow in another repo that's kicked off manually without any pull request.

For those reasons, this PR:
- introduces a more generic variable "UNIQUE_ENV_NAME" instead of having the opinionated naming convention
- cleans up the code (variable names, comments, etc.) to remove the assumption that the context is a PR for all use cases